### PR TITLE
Prevent chests demanding items unless there is space

### DIFF
--- a/src/main/java/net/pcal/amazingchest/AcReachabilityDelegate.java
+++ b/src/main/java/net/pcal/amazingchest/AcReachabilityDelegate.java
@@ -19,6 +19,8 @@ import static net.pcal.amazingchest.AcReachabilityCache.TransferDisposition.ACCE
 import static net.pcal.amazingchest.AcReachabilityCache.TransferDisposition.DEMAND;
 import static net.pcal.amazingchest.AcReachabilityCache.TransferDisposition.REJECT;
 import static net.pcal.amazingchest.AcUtils.as;
+import static net.pcal.amazingchest.AcUtils.hasSpaceFor;
+import static net.pcal.amazingchest.AcUtils.getInventoryFor;
 
 @SuppressWarnings("SpellCheckingInspection")
 public enum AcReachabilityDelegate implements ReachabilityDelegate<HopperBlockEntity, Item> {
@@ -85,6 +87,13 @@ public enum AcReachabilityDelegate implements ReachabilityDelegate<HopperBlockEn
 
         @Override
         public TransferDisposition getDispositionToward(Item item) {
+
+            // If the amazing chest has no space for the item,
+            // reject it.
+            if (!hasSpaceFor(getInventoryFor(this.acbe), item)) {
+                return REJECT;
+            }
+
             return AcUtils.containsAtLeast(this.acbe, requireNonNull(item), 1) ? DEMAND : REJECT;
         }
     }

--- a/src/main/java/net/pcal/amazingchest/AcService.java
+++ b/src/main/java/net/pcal/amazingchest/AcService.java
@@ -32,6 +32,8 @@ import static net.pcal.amazingchest.AcReachabilityCache.TransferDisposition.REJE
 import static net.pcal.amazingchest.AcService.CacheInvalidationPolicy.AGGRESSIVE_INVALIDATION;
 import static net.pcal.amazingchest.AcUtils.as;
 import static net.pcal.amazingchest.AcUtils.containsAtLeast;
+import static net.pcal.amazingchest.AcUtils.getInventoryFor;
+import static net.pcal.amazingchest.AcUtils.hasSpaceFor;
 
 /**
  * Central singleton service.
@@ -257,6 +259,13 @@ public class AcService implements PlayerBlockBreakEvents.After {
         }
         final AmazingChestBlockEntity targetAmazingChest = as(targetBlock, AmazingChestBlockEntity.class);
         if (targetAmazingChest != null) {
+
+            // If the amazing chest has no space for the item,
+            // reject it.
+            if(!hasSpaceFor(getInventoryFor(targetAmazingChest), item)) {
+                return REJECT;
+            }
+
             // if they're trying to put it into an AC, veto it if the chest doesn't have one
             return containsAtLeast(targetAmazingChest, item, 1) ? DEMAND : REJECT;
         }

--- a/src/main/java/net/pcal/amazingchest/AcUtils.java
+++ b/src/main/java/net/pcal/amazingchest/AcUtils.java
@@ -49,9 +49,33 @@ public interface AcUtils {
     /**
      * @return the inventory for the given chest.  This is necessary to account for the case of a double chest.
      */
-    private static Inventory getInventoryFor(AmazingChestBlockEntity ace) {
+    static Inventory getInventoryFor(AmazingChestBlockEntity ace) {
         requireNonNull(ace, "ace");
         final BlockState blockState = ace.getWorld().getBlockState(ace.getPos());
         return ChestBlock.getInventory((ChestBlock) blockState.getBlock(), blockState, ace.getWorld(), ace.getPos(), false);
+    }
+
+    /**
+     * Check if an inventory has space for the given item
+    */
+    static Boolean hasSpaceFor(Inventory inventory, Item item) {
+
+        // check each slot in the inventory
+        for (int i = 0; i < inventory.size(); i++) {
+
+            ItemStack stack = inventory.getStack(i);
+
+            if(stack.isEmpty()) return true;
+
+            // no need to count stacks of items that don't match the item that is being pushed.
+            if(stack.getItem() != item) continue;
+
+            // check if the stack of items is full or not
+            if(stack.getMaxCount() > stack.getCount()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/main/java/net/pcal/amazingchest/AcUtils.java
+++ b/src/main/java/net/pcal/amazingchest/AcUtils.java
@@ -61,7 +61,7 @@ public interface AcUtils {
     static Boolean hasSpaceFor(Inventory inventory, Item item) {
 
         // inventory is null when chest has a full block above it that stops you openning the chest
-        if(inventory == null) return true;
+        if(inventory == null) return false;
 
         // check each slot in the inventory
         for (int i = 0; i < inventory.size(); i++) {

--- a/src/main/java/net/pcal/amazingchest/AcUtils.java
+++ b/src/main/java/net/pcal/amazingchest/AcUtils.java
@@ -60,6 +60,9 @@ public interface AcUtils {
     */
     static Boolean hasSpaceFor(Inventory inventory, Item item) {
 
+        // inventory is null when chest has a full block above it that stops you openning the chest
+        if(inventory == null) return true;
+
         // check each slot in the inventory
         for (int i = 0; i < inventory.size(); i++) {
 


### PR DESCRIPTION
Hi! Firstly, this is a great mod - I like that it keeps a pretty vanilla feel while adding great auto-sorting functions. 

I was wondering - are you open to PRs for this? I have a couple of things I've been tinkering with while trying this mod out on a couple of worlds. This PR is for one of them (they're pretty separate features so I thought I should separate them, in case you want to include one but not the other.) 

This adds a check to see if any given item can fit into the amazing chest's inventory. If it cannot fit, it is rejected, allowing the item to flow to another chest in the hopper chain (e.g. an overflow chest, or a 2nd amazing chest with the same item filter). 

I saw issue #3 related to multiple chests with the same filters, where you were thinking of distributing items evenly. I guess this change is incompatible with that idea, so feel free to reject this PR if it doesn't fit with how you want to develop the mod :) 

Also - I'm very new to Java, so let me know if I've done anything silly here! Would love to learn more about Minecraft modding.


