### PR TITLE
Keep stacks in place

### DIFF
--- a/src/main/java/net/pcal/amazingchest/AcInitializer.java
+++ b/src/main/java/net/pcal/amazingchest/AcInitializer.java
@@ -20,6 +20,8 @@ import net.minecraft.item.ItemGroup;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.registry.Registry;
 import net.pcal.amazingchest.AcService.CacheInvalidationPolicy;
+import net.pcal.amazingchest.AcService.PullPolicy;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -130,7 +132,20 @@ public class AcInitializer implements ModInitializer, ClientModInitializer {
                 cachePolicy = CacheInvalidationPolicy.valueOf(configuredCachePolicy);
                 logger.info(LOG_PREFIX + "cachePolicy set to " + cachePolicy);
             }
-            AcService.initialize(cachePolicy, logger);
+
+            // get the pulling policy
+            final String configuredPullPolicy = config.getProperty("pull-policy");
+
+            final PullPolicy pullPolicy;
+            if(configuredPullPolicy == null) {
+                pullPolicy = PullPolicy.DEFAULT;
+            } else {
+                pullPolicy = PullPolicy.valueOf(configuredPullPolicy);
+                logger.info(LOG_PREFIX + "pullPolicy set to " + pullPolicy);
+            }
+
+
+            AcService.initialize(cachePolicy, pullPolicy, logger);
 
             AcLockPacket.registerReceivePacket();
 

--- a/src/main/java/net/pcal/amazingchest/AcService.java
+++ b/src/main/java/net/pcal/amazingchest/AcService.java
@@ -89,6 +89,10 @@ public class AcService implements PlayerBlockBreakEvents.After {
         return this.logger;
     }
 
+    PullPolicy getPullPolicy() {
+        return this.pullPolicy;
+    }
+
     // ===================================================================================
     // PlayerBlockBreakEvents listener
 

--- a/src/main/resources/default-amazingchest.properties
+++ b/src/main/resources/default-amazingchest.properties
@@ -26,3 +26,12 @@
 # Other valid values: AGGRESSIVE_INVALIDATION, NO_CACHE
 #
 # cache-policy = DEFAULT
+
+#
+# Controls whether amazing chests:
+# - keep the last item of each type in inventory, (DEFAULT)
+# - keep the last item of each *stack* (PER_STACK)
+# Change this if you like to organise the position of different items in your chests visually.
+# Valid values = DEFAULT, PER_STACK.
+#
+# pull-policy = DEFAULT


### PR DESCRIPTION
This PR adds an option to keep the last item in every slot when an amazing chest is locked - not just the last item of a given type in the whole chest. 

I wanted this feature for one of my worlds where we have items organised into specific slots for chests (e.g. iron in the top row of a chest, copper in the 2nd row, etc). I realise it's probably not what most people want, and it probably isn't good for people who use this to sort unstackable items, so I added a new property (`pull-policy`) that means the user can manually enable this functionality if they want it, or ignore it if they don't.

Happy to take feedback on either of these PRs; if you think something should be done differently, or if you'd rather think through the features more carefully before adding them in, let me know. 

Thanks again for the great mod!


